### PR TITLE
chore(ide): improve file nesting rules for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,9 +11,8 @@
   "editor.bracketPairColorization.enabled": true,
   "explorer.fileNesting.enabled": true,
   "explorer.fileNesting.patterns": {
-    "*.ts": "${capture}.js",
+    "*.ts": "${capture}.js, ${capture}.html, ${capture}.css, ${capture}.spec.ts",
     "*.js": "${capture}.js.map, ${capture}.min.js, ${capture}.d.ts",
-    "*.component.ts": "${capture}.component.html, ${capture}.component.css, ${capture}.component.spec.ts",
     "package.json": "package-lock.json, yarn.lock",
     ".eslintrc*": ".eslintignore, .eslintcache",
     ".prettierrc*": ".prettierignore",


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--
Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.
https://guides.github.com/features/mastering-markdown/
-->

### What does it do

Improves the file nesting rules for Angular files implemented in b405828914e1abd29e37db570e7d79d517c7a1a7.

### Usage

You should see more Angular files getting nested.

### Why is it needed

DX

### Related issue(s)/PR(s)

File nesting was initially implemented in b405828914e1abd29e37db570e7d79d517c7a1a7.
