### PR TITLE
fix(service): use new endpoint in JobsService

### DIFF
--- a/src/app/jobs/services/jobs.service.ts
+++ b/src/app/jobs/services/jobs.service.ts
@@ -12,7 +12,7 @@ import { environment } from "src/environments/environment";
   providedIn: "root",
 })
 export class JobsService {
-  private basePath = `${environment.apiUrlBase}/jobOffers`;
+  private basePath = `${environment.apiUrlBase}/jobs`;
 
   private httpOptions = {
     headers: new HttpHeaders({


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--
Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.
https://guides.github.com/features/mastering-markdown/
-->

### What does it do

In the latest update to the database file, the Jobs endpoint was changed from `/jobOffers` to `/jobs`. This PR fixes `JobsService` to use the new endpoint.

### Why is it needed

Production is broken due to this.

### Related issue(s)/PR(s)

#18, synced from futureleadersupc/waw-backend-json#3.
