### PR TITLE
feat(ui): Initial implementation of base layout

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,3 @@
 <app-header></app-header>
 <router-outlet></router-outlet>
+<app-footer></app-footer>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,10 +1,2 @@
-<mat-toolbar color="primary" class="flex justify-between">
-  <h1>WAW</h1>
-
-  <div class="space-x-1">
-    <button mat-button routerLink="/">Home</button>
-    <button mat-button routerLink="/account/jobs">Jobs</button>
-  </div>
-</mat-toolbar>
-
+<app-header></app-header>
 <router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from "@angular/core";
+import { MatIconRegistry } from "@angular/material/icon";
 
 @Component({
   selector: "app-root",
@@ -7,4 +8,12 @@ import { Component } from "@angular/core";
 })
 export class AppComponent {
   title = "waw-frontend-angular";
+
+  constructor(private iconRegistry: MatIconRegistry) {
+    iconRegistry.registerFontClassAlias(
+      "material-symbols-outlined",
+      "material-symbols-outlined"
+    );
+    iconRegistry.setDefaultFontSetClass("material-symbols-outlined");
+  }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,6 +16,7 @@ import { MatPaginatorModule } from "@angular/material/paginator";
 import { MatSortModule } from "@angular/material/sort";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { MatSelectModule } from "@angular/material/select";
+import { MatMenuModule } from "@angular/material/menu";
 
 import { AppRoutingModule } from "./app-routing.module";
 import { AppComponent } from "./app.component";
@@ -23,6 +24,7 @@ import { ProfileComponent } from "./core/pages/profile/profile.component";
 import { SignInComponent } from "./auth/pages/signin/signin.component";
 import { SignUpComponent } from "./auth/pages/signup/signup.component";
 import { JobsComponent } from "./jobs/pages/jobs/jobs.component";
+import { HeaderComponent } from "./common/components/header/header.component";
 
 export const imports: NonNullable<NgModule["imports"]> = [
   AppRoutingModule,
@@ -41,6 +43,7 @@ export const imports: NonNullable<NgModule["imports"]> = [
   MatSortModule,
   MatTooltipModule,
   MatSelectModule,
+  MatMenuModule,
 ];
 
 @NgModule({
@@ -50,6 +53,7 @@ export const imports: NonNullable<NgModule["imports"]> = [
     SignInComponent,
     SignUpComponent,
     JobsComponent,
+    HeaderComponent,
   ],
   imports: [BrowserModule, ...imports],
   providers: [],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -32,6 +32,7 @@ import { MatMenuModule } from "@angular/material/menu";
 import { MatDialogModule } from "@angular/material/dialog";
 import { MatSnackBarModule } from "@angular/material/snack-bar";
 import { MatProgressBarModule } from "@angular/material/progress-bar";
+import { FooterComponent } from "./common/components/footer/footer.component";
 
 export const imports: NonNullable<NgModule["imports"]> = [
   AppRoutingModule,
@@ -68,6 +69,7 @@ export const imports: NonNullable<NgModule["imports"]> = [
     JobConfirmationDialogComponent,
     ResetpasswordComponent,
     ChangepasswordComponent,
+    FooterComponent,
   ],
   imports: [BrowserModule, ...imports],
   providers: [],

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,13 +3,7 @@ import { BrowserModule } from "@angular/platform-browser";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { HttpClientModule } from "@angular/common/http";
 import { FormsModule } from "@angular/forms";
-
-import { AppRoutingModule } from "./app-routing.module";
-import { AppComponent } from "./app.component";
-import { ProfileComponent } from "./core/pages/profile/profile.component";
-import { SignInComponent } from "./auth/pages/signin/signin.component";
-import { SignUpComponent } from "./auth/pages/signup/signup.component";
-import { JobsComponent } from "./jobs/pages/jobs/jobs.component";
+import { LayoutModule } from "@angular/cdk/layout";
 
 import { MatToolbarModule } from "@angular/material/toolbar";
 import { MatIconModule } from "@angular/material/icon";
@@ -23,11 +17,19 @@ import { MatSortModule } from "@angular/material/sort";
 import { MatTooltipModule } from "@angular/material/tooltip";
 import { MatSelectModule } from "@angular/material/select";
 
+import { AppRoutingModule } from "./app-routing.module";
+import { AppComponent } from "./app.component";
+import { ProfileComponent } from "./core/pages/profile/profile.component";
+import { SignInComponent } from "./auth/pages/signin/signin.component";
+import { SignUpComponent } from "./auth/pages/signup/signup.component";
+import { JobsComponent } from "./jobs/pages/jobs/jobs.component";
+
 export const imports: NonNullable<NgModule["imports"]> = [
   AppRoutingModule,
   BrowserAnimationsModule,
   HttpClientModule,
   FormsModule,
+  LayoutModule,
   MatToolbarModule,
   MatIconModule,
   MatFormFieldModule,

--- a/src/app/auth/pages/changepassword/changepassword.component.html
+++ b/src/app/auth/pages/changepassword/changepassword.component.html
@@ -1,9 +1,8 @@
-<div class="flex justify-center items-center">
-  <div class="flex flex-col container max-w-md items-center mt-8 space-y-4">
+<div class="flex justify-center items-center my-12 xl:my-16 2xl:my-48">
+  <div class="flex flex-col container max-w-md items-center space-y-4">
     <div class="mb-6">
       <span class="text-2xl font-semibold">Change Password</span>
     </div>
-    <!--inputs-->
     <mat-form-field appearance="outline" class="w-full">
       <mat-label> Put a New Password</mat-label>
       <input matInput type="password" class="w-full" />
@@ -19,8 +18,10 @@
       </button>
     </div>
     <div class="my-2">
-      <span >Click here to </span>
-      <span class="font-semibold" routerLink="/account/resetpassword"> Login </span>
+      <span>Click here to </span>
+      <span class="font-semibold" routerLink="/account/resetpassword">
+        Login
+      </span>
     </div>
   </div>
 </div>

--- a/src/app/auth/pages/resetpassword/resetpassword.component.html
+++ b/src/app/auth/pages/resetpassword/resetpassword.component.html
@@ -1,17 +1,15 @@
-<div class="flex justify-center items-center">
-  <div class="flex flex-col container max-w-md items-center mt-8 space-y-4">
+<div class="flex justify-center items-center my-12 xl:my-16 2xl:my-48">
+  <div class="flex flex-col container max-w-md items-center space-y-4">
     <div class="mb-6">
       <span class="text-2xl font-semibold">Forgot Password?</span>
     </div>
-    <!--inputs-->
     <mat-form-field appearance="outline" class="w-full">
       <mat-label>Email</mat-label>
       <input
         matInput
         type="text"
         placeholder="john.doe@gmail.com"
-        class="w-full">
-      <!--        [(ngModel)]="this.email" />-->
+        class="w-full" />
     </mat-form-field>
     <div class="my-2 w-full">
       <button
@@ -24,8 +22,9 @@
       <span>follow the instructions that we will send you by mail</span>
     </div>
     <div>
-      <span class="font-semibold" routerLink="/account/changepassword"> Change Password </span>
-
+      <span class="font-semibold" routerLink="/account/changepassword">
+        Change Password
+      </span>
     </div>
   </div>
 </div>

--- a/src/app/auth/pages/signin/signin.component.html
+++ b/src/app/auth/pages/signin/signin.component.html
@@ -1,5 +1,5 @@
-<div class="flex justify-center items-center">
-  <div class="flex flex-col container max-w-md items-center mt-8 space-y-4">
+<div class="flex justify-center items-center my-12 xl:my-16 2xl:my-48">
+  <div class="flex flex-col container max-w-md items-center space-y-4">
     <div class="mb-6">
       <span class="text-2xl font-semibold">Sign in</span>
     </div>

--- a/src/app/auth/pages/signup/signup.component.html
+++ b/src/app/auth/pages/signup/signup.component.html
@@ -1,9 +1,8 @@
-<div class="flex justify-center items-center">
-  <div class="flex flex-col container max-w-md items-center mt-8 space-y-4">
+<div class="flex justify-center items-center my-12 xl:my-16 2xl:my-48">
+  <div class="flex flex-col container max-w-md items-center space-y-4">
     <div class="mb-6">
       <span class="text-2xl font-semibold">Create an account</span>
     </div>
-    <!--inputs-->
     <mat-form-field appearance="outline" class="w-full">
       <mat-label>Full name</mat-label>
       <input matInput type="text" placeholder="John Doe" class="w-full" />

--- a/src/app/common/components/footer/footer.component.html
+++ b/src/app/common/components/footer/footer.component.html
@@ -1,0 +1,26 @@
+<footer
+  class="px-4 py-8 md:p-8 flex flex-col md:flex-row md:justify-between bg-slate-50">
+  <div class="space-y-2 flex flex-col order-last md:order-none">
+    <span class="text-2xl font-bold">WAW</span>
+    <span class="text-sm font-light">© Future Leaders Inc., 2022</span>
+  </div>
+  <nav
+    class="space-y-12 md:space-y-0 md:space-x-8 lg:space-x-24 flex flex-col md:flex-row mb-24 md:mb-0 text-xs text-slate-800">
+    <div *ngFor="let group of navigation" class="space-y-4 flex flex-col">
+      <span class="font-medium">{{ group.label }}</span>
+      <span *ngFor="let link of group.items">
+        {{ link.label }}
+      </span>
+    </div>
+  </nav>
+  <div class="flex flex-col mb-24 md:mb-0">
+    <mat-form-field appearance="fill" class="w-32 text-sm">
+      <mat-label>Language</mat-label>
+      <mat-select [(value)]="selectedLanguage">
+        <mat-option *ngFor="let language of languages" [value]="language.code">
+          {{ language.label }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+</footer>

--- a/src/app/common/components/footer/footer.component.spec.ts
+++ b/src/app/common/components/footer/footer.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { FooterComponent } from "./footer.component";
+
+import { imports } from "src/app/app.module";
+
+describe("FooterComponent", () => {
+  let component: FooterComponent;
+  let fixture: ComponentFixture<FooterComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [...imports],
+      declarations: [FooterComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FooterComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/common/components/footer/footer.component.ts
+++ b/src/app/common/components/footer/footer.component.ts
@@ -1,0 +1,40 @@
+import { Component } from "@angular/core";
+import { LanguageDef, Languages, NestedNavItem } from "../../model/navigation";
+
+@Component({
+  selector: "app-footer",
+  templateUrl: "./footer.component.html",
+  styleUrls: ["./footer.component.css"],
+})
+export class FooterComponent {
+  navigation: NestedNavItem[] = [
+    {
+      label: "Company",
+      items: [
+        { label: "About" },
+        { label: "Careers" },
+        { label: "Advertising" },
+        { label: "Small Business" },
+      ],
+    },
+    {
+      label: "Help",
+      items: [
+        { label: "Safety Center" },
+        { label: "Knowledge Base" },
+        { label: "Contact Us" },
+      ],
+    },
+    {
+      label: "Legal",
+      items: [{ label: "Community Guidelines" }, { label: "Privacy & Terms" }],
+    },
+  ];
+
+  languages: LanguageDef[] = [
+    { label: "English", code: "en_US" },
+    { label: "Spanish", code: "es_PE" },
+  ];
+
+  selectedLanguage: Languages = "en_US";
+}

--- a/src/app/common/components/header/header.component.html
+++ b/src/app/common/components/header/header.component.html
@@ -1,0 +1,83 @@
+<header
+  role="heading"
+  class="px-4 md:px-8 flex items-center h-20 justify-between sm:justify-start sm:space-x-8 bg-white">
+  <div class="flex items-center h-full space-x-8">
+    <a routerLink="/">
+      <h1 class="text-2xl font-bold">WAW</h1>
+    </a>
+    <nav
+      *ngIf="user !== null"
+      class="h-full pl-8 hidden md:flex items-center border-l border-slate-200">
+      <ul class="flex text-center space-x-12">
+        <a *ngFor="let item of navigation" [routerLink]="item.path">
+          <li class="flex flex-col items-center space-y-2">
+            <mat-icon class="mat-icon-6">
+              {{ item.icon }}
+            </mat-icon>
+            <span class="text-xs font-medium uppercase">
+              {{ item.label }}
+            </span>
+          </li>
+        </a>
+      </ul>
+    </nav>
+  </div>
+  <div
+    class="h-full w-full hidden sm:flex items-center border-x border-slate-200">
+    <mat-icon class="ml-4 mat-icon-6 text-slate-400">search</mat-icon>
+    <input
+      [(ngModel)]="currentSearch"
+      class="px-4 py-3 h-full w-full bg-transparent placeholder:font-light placeholder:text-base placeholder:text-slate-400"
+      [placeholder]="breakpoints.lgPlus ? 'Quick search...' : 'Search...'" />
+  </div>
+  <div
+    class="flex items-center shrink-0 space-x-4 cursor-pointer"
+    [mat-menu-trigger-for]="accountMenu">
+    <div class="rounded-full overflow-hidden w-8 h-8">
+      <img
+        [src]="user?.picture?.href"
+        class="object-cover h-full"
+        *ngIf="user !== null" />
+      <mat-icon *ngIf="user === null" class="mat-icon-8">
+        account_circle
+      </mat-icon>
+    </div>
+    <div class="hidden lg:flex flex-col space-y-1">
+      <span class="text-xs font-medium">
+        Hello, {{ user !== null ? user.preferredName : "Sign In" }}
+      </span>
+      <span *ngIf="user !== null" class="text-xs font-normal text-slate-600">
+        {{ user.profileViews }} views today
+      </span>
+    </div>
+    <mat-icon class="hidden lg:inline-block">expand_more</mat-icon>
+  </div>
+  <mat-menu #accountMenu="matMenu" xPosition="before" class="mt-2 w-40">
+    <ul role="menu">
+      <li *ngFor="let option of accountMenuOptions" role="none">
+        <a
+          *ngIf="option.path && handleVisibile(option.visible)"
+          [routerLink]="option.path"
+          role="menuitem">
+          <button mat-menu-item class="flex items-center">
+            <mat-icon class="mat-icon-6">{{ option.icon }}</mat-icon>
+            <span>{{ option.label }}</span>
+          </button>
+        </a>
+        <button
+          *ngIf="option.command && handleVisibile(option.visible)"
+          (click)="option.command()"
+          mat-menu-item
+          class="flex items-center"
+          role="menuitem">
+          <mat-icon class="mat-icon-6">{{ option.icon }}</mat-icon>
+          <span>{{ option.label }}</span>
+        </button>
+        <span
+          *ngIf="option.separator && handleVisibile(option.visible)"
+          class="my-2 border-t border-gray-300 block w-full"
+          role="separator"></span>
+      </li>
+    </ul>
+  </mat-menu>
+</header>

--- a/src/app/common/components/header/header.component.spec.ts
+++ b/src/app/common/components/header/header.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+
+import { HeaderComponent } from "./header.component";
+
+describe("HeaderComponent", () => {
+  let component: HeaderComponent;
+  let fixture: ComponentFixture<HeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [HeaderComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/common/components/header/header.component.spec.ts
+++ b/src/app/common/components/header/header.component.spec.ts
@@ -2,12 +2,15 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { HeaderComponent } from "./header.component";
 
+import { imports } from "src/app/app.module";
+
 describe("HeaderComponent", () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [...imports],
       declarations: [HeaderComponent],
     }).compileComponents();
   });

--- a/src/app/common/components/header/header.component.ts
+++ b/src/app/common/components/header/header.component.ts
@@ -1,0 +1,89 @@
+import { Component, OnDestroy, OnInit } from "@angular/core";
+import { Router } from "@angular/router";
+import { UseUser } from "src/app/auth/hooks/use-user";
+import { AuthService } from "src/app/auth/services/auth.service";
+import { ProjectsService } from "src/app/auth/services/projects.service";
+import { MenuItem, NavItem } from "../../model/navigation";
+import { ResponsiveService } from "../../services/responsive.service";
+
+@Component({
+  selector: "app-header",
+  templateUrl: "./header.component.html",
+  styleUrls: ["./header.component.css"],
+})
+export class HeaderComponent extends UseUser implements OnInit, OnDestroy {
+  navigation: NavItem[] = [
+    { label: "Home", path: "/", icon: "home" },
+    { label: "Jobs", path: "/account/jobs", icon: "work" },
+    { label: "Chat", path: "/chat", icon: "chat" },
+    { label: "Notices", path: "/notifications", icon: "notifications" },
+  ];
+  accountMenuOptions: MenuItem[] = [
+    {
+      label: "Sign In",
+      path: "/account/signin",
+      icon: "login",
+      visible: () => this.user === null,
+    },
+    {
+      label: "Sign Up",
+      path: "/account/signup",
+      icon: "person_add_alt_1",
+      visible: () => this.user === null,
+    },
+    ...this.navigation.map<MenuItem>(item => ({
+      ...item,
+      visible: () => this.user !== null,
+    })),
+    { separator: true, visible: () => this.user !== null },
+    {
+      label: "Profile",
+      path: "/account/profile",
+      icon: "person",
+      visible: () => this.user !== null,
+    },
+    {
+      label: "Settings",
+      path: "/account/settings",
+      icon: "settings",
+      visible: () => this.user !== null,
+    },
+    {
+      label: "Sign Out",
+      icon: "logout",
+      visible: () => this.user !== null,
+      command: () => {
+        this.authService.logout();
+        this.router.navigate(["/account/signin"]);
+      },
+    },
+  ];
+  currentSearch = "";
+
+  constructor(
+    authService: AuthService,
+    projectsService: ProjectsService,
+    private responsiveService: ResponsiveService,
+    private router: Router
+  ) {
+    super(authService, projectsService);
+  }
+
+  get breakpoints() {
+    return this.responsiveService.breakpoints;
+  }
+
+  handleVisibile(value: MenuItem["visible"]): boolean {
+    if (!value) return false;
+    if (typeof value === "boolean") return value;
+    return value();
+  }
+
+  ngOnInit(): void {
+    this.handleUserInit();
+  }
+
+  ngOnDestroy(): void {
+    this.handleUserDestroy();
+  }
+}

--- a/src/app/common/model/navigation.ts
+++ b/src/app/common/model/navigation.ts
@@ -29,3 +29,15 @@ export type MenuItem = {
       command: (event?: Event) => void;
     }
 );
+
+export type NestedNavItem = {
+  label: string;
+  items?: NestedNavItem[];
+};
+
+export type Languages = "en_US" | "es_PE";
+
+export type LanguageDef = {
+  label: string;
+  code: Languages;
+};

--- a/src/app/common/model/navigation.ts
+++ b/src/app/common/model/navigation.ts
@@ -1,0 +1,31 @@
+export type NavItem = {
+  label: string;
+  path: string;
+  icon: string;
+};
+
+export type MenuItem = {
+  visible?: boolean | (() => boolean);
+} & (
+  | {
+      label: string;
+      path: string;
+      icon: string;
+      separator?: false;
+      command?: never;
+    }
+  | {
+      label?: never;
+      path?: never;
+      icon?: never;
+      separator: true;
+      command?: never;
+    }
+  | {
+      label: string;
+      path?: never;
+      icon: string;
+      separator?: false;
+      command: (event?: Event) => void;
+    }
+);

--- a/src/app/common/services/responsive.service.spec.ts
+++ b/src/app/common/services/responsive.service.spec.ts
@@ -1,0 +1,19 @@
+import { TestBed } from "@angular/core/testing";
+import { HttpClientModule } from "@angular/common/http";
+
+import { ResponsiveService } from "./responsive.service";
+
+describe("ResponsiveService", () => {
+  let service: ResponsiveService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientModule],
+    });
+    service = TestBed.inject(ResponsiveService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/common/services/responsive.service.ts
+++ b/src/app/common/services/responsive.service.ts
@@ -1,0 +1,66 @@
+import { Injectable, OnDestroy } from "@angular/core";
+import { BreakpointObserver } from "@angular/cdk/layout";
+import { Subscription } from "rxjs";
+import { TailwindBreakpoints } from "../utils/breakpoints";
+
+export const AppBreakpoints = TailwindBreakpoints;
+export type Breakpoints = keyof typeof AppBreakpoints;
+export type AllBreakpoints =
+  | Breakpoints
+  | `${Breakpoints}Minus`
+  | `${Breakpoints}Plus`;
+export type ParsedBreakpoints = Record<AllBreakpoints, boolean>;
+export type MappedBreakpoints = Record<string, AllBreakpoints>;
+
+@Injectable({
+  providedIn: "root",
+})
+export class ResponsiveService implements OnDestroy {
+  breakpoints: ParsedBreakpoints;
+  private breakpointMapping: MappedBreakpoints;
+  private breakpointSubscription: Subscription;
+
+  constructor(protected breakpointObserver: BreakpointObserver) {
+    const keys = Object.keys(AppBreakpoints) as Breakpoints[];
+
+    this.breakpoints = keys.reduce<Record<string, boolean>>((acc, value) => {
+      acc[value] = false;
+      acc[`${value}Minus`] = false;
+      acc[`${value}Plus`] = false;
+      return acc;
+    }, {}) as ParsedBreakpoints;
+
+    this.breakpointMapping = keys.reduce<MappedBreakpoints>(
+      (acc, value, index, arr) => {
+        const px = AppBreakpoints[value];
+
+        acc[`(max-width: ${px - 0.02}px)`] = `${value}Minus`;
+        if (index + 1 >= arr.length) {
+          acc[`(min-width): ${px}px`] = value;
+        } else {
+          const next = `${AppBreakpoints[arr[index + 1]] - 0.02}`;
+          acc[`(min-width: ${px}px) and (max-width: ${next}px)`] = value;
+        }
+        acc[`(min-width: ${px}px)`] = `${value}Plus`;
+        return acc;
+      },
+      {}
+    );
+
+    const queries = Object.keys(this.breakpointMapping);
+
+    this.breakpointSubscription = this.breakpointObserver
+      .observe(queries)
+      .subscribe(result => {
+        for (const query of Object.keys(result.breakpoints)) {
+          const breakpoint = this.breakpointMapping[query];
+          this.breakpoints[breakpoint] = result.breakpoints[query];
+        }
+        console.log(this.breakpoints);
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.breakpointSubscription.unsubscribe();
+  }
+}

--- a/src/app/common/utils/breakpoints.ts
+++ b/src/app/common/utils/breakpoints.ts
@@ -1,0 +1,7 @@
+export const TailwindBreakpoints = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  "2xl": 1536,
+};

--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,7 @@
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
       rel="stylesheet" />
   </head>
-  <body>
+  <body class="mat-overrides">
     <app-root></app-root>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -18,7 +18,7 @@
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet" />
   </head>
-  <body class="mat-typography">
+  <body>
     <app-root></app-root>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
       href="https://fonts.googleapis.com/css2?family=Roboto:wght@100;300;400;500;700&display=swap"
       rel="stylesheet" />
     <link
-      href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
       rel="stylesheet" />
   </head>
   <body>

--- a/src/plugins/tailwind/mat-icon-sizes.js
+++ b/src/plugins/tailwind/mat-icon-sizes.js
@@ -1,0 +1,28 @@
+/** @type {import("tailwindcss/plugin").TailwindPluginCreator} */
+const plugin = require("tailwindcss/plugin");
+
+const matIconSizesPlugin = plugin(({ addBase, matchUtilities, theme }) => {
+  const spacing = theme("spacing");
+
+  addBase({
+    ".mat-overrides .mat-icon": {
+      width: "var(--mat-icon-size, unset)",
+      height: "var(--mat-icon-size, unset)",
+    },
+  });
+
+  matchUtilities(
+    {
+      "mat-icon": value => ({
+        "--mat-icon-size": value,
+        fontSize: value,
+        lineHeight: 1,
+      }),
+    },
+    {
+      values: spacing,
+    }
+  );
+});
+
+module.exports = matIconSizesPlugin;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,5 +16,5 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [require("./src/plugins/tailwind/mat-icon-sizes")],
 };


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--
Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.
https://guides.github.com/features/mastering-markdown/
-->

### What does it do

This pull request aims to include the implementations we did on futureleadersupc/waw-frontend-vue#7, rewritten using Angular. It also includes a couple of changes that will also be ported back to Vue.js.

- [x] Responsive layout service
- [x] Header component
- [x] Footer component

### Usage

The components will replace the current placeholders once this pull request is merged. This also includes changes to the icons we are using in the app. Documentation for them can be found [here](https://fonts.google.com/icons?icon.set=Material+Symbols).

This pull request also includes a custom plugin for Tailwind that allows us to override the size of any icons used with the `<mat-icon>` component.

### Why is it needed

Feature parity with Vue.js.

### Related issue(s)/PR(s)

The original implementation was done in futureleadersupc/waw-frontend-vue#7.

